### PR TITLE
always unpack initrd to relative paths

### DIFF
--- a/abootimg-unpack-initrd
+++ b/abootimg-unpack-initrd
@@ -16,5 +16,5 @@ fi
 
 mkdir -p $ramdisk
 
-zcat $initrd | ( cd $ramdisk; cpio -i )
+zcat $initrd | ( cd $ramdisk; cpio -i --no-absolute-filenames)
 


### PR DESCRIPTION
If cpio archive contains absolute filenames, files are unpacked
relative to host root '/', not 'ramdisk' directory.
If abootimg-unpack-initrd is run as root, that could break host system
and make it unbootable by overwriting important system files.